### PR TITLE
Migrate from deprecated Data::Entropy to Crypt::PRNG

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -30,7 +30,7 @@ Module::Build->new(
 		"Crypt::MySQL" => "0.03",
 		"Crypt::PasswdMD5" => "1.0",
 		"Crypt::UnixCrypt_XS" => "0.08",
-		"Data::Entropy::Algorithms" => 0,
+		"Crypt::PRNG" => 0,
 		"Digest" => "1.00",
 		"Digest::MD4" => "1.2",
 		"Digest::MD5" => "1.9953",

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+{{$NEXT}}
+
+  * Data::Entropy is deprecated. Migrate to Crypt::PRNG (Mathieu Arnold)
+  
 version 0.008; 2012-02-04
 
   * bugfix: avoid passing magic variables $1 et al into functions where

--- a/META.json
+++ b/META.json
@@ -42,7 +42,7 @@
             "Crypt::MySQL" : "0.03",
             "Crypt::PasswdMD5" : "1.0",
             "Crypt::UnixCrypt_XS" : "0.08",
-            "Data::Entropy::Algorithms" : 0,
+            "Crypt::PRNG" : 0,
             "Digest" : "1.00",
             "Digest::MD4" : "1.2",
             "Digest::MD5" : "1.9953",

--- a/META.yml
+++ b/META.yml
@@ -88,7 +88,7 @@ requires:
   Crypt::MySQL: 0.03
   Crypt::PasswdMD5: 1.0
   Crypt::UnixCrypt_XS: 0.08
-  Data::Entropy::Algorithms: 0
+  Crypt::PRNG: 0
   Digest: 1.00
   Digest::MD4: 1.2
   Digest::MD5: 1.9953

--- a/lib/Authen/Passphrase/BigCrypt.pm
+++ b/lib/Authen/Passphrase/BigCrypt.pm
@@ -73,7 +73,7 @@ use Authen::Passphrase 0.003;
 use Authen::Passphrase::DESCrypt;
 use Carp qw(croak);
 use Crypt::UnixCrypt_XS 0.08 qw(base64_to_block base64_to_int12);
-use Data::Entropy::Algorithms 0.000 qw(rand_int);
+use Crypt::PRNG 0.000 qw(irand);
 
 our $VERSION = "0.008";
 
@@ -150,7 +150,7 @@ sub new {
 				if defined $salt;
 			croak "\"$value\" is not a valid salt size"
 				unless $value == 12;
-			$salt = rand_int(1 << $value);
+			$salt = irand() % (1 << $value);
 		} elsif($attr eq "hash") {
 			croak "hash specified redundantly"
 				if @hashes || defined($passphrase);

--- a/lib/Authen/Passphrase/BlowfishCrypt.pm
+++ b/lib/Authen/Passphrase/BlowfishCrypt.pm
@@ -98,7 +98,7 @@ use strict;
 use Authen::Passphrase 0.003;
 use Carp qw(croak);
 use Crypt::Eksblowfish::Bcrypt 0.008 qw(bcrypt_hash en_base64 de_base64);
-use Data::Entropy::Algorithms 0.000 qw(rand_bits);
+use Crypt::PRNG 0.000 qw(random_bytes);
 
 our $VERSION = "0.008";
 
@@ -194,7 +194,7 @@ sub new {
 		} elsif($attr eq "salt_random") {
 			croak "salt specified redundantly"
 				if exists $self->{salt};
-			$self->{salt} = rand_bits(128);
+			$self->{salt} = random_bytes(16);
 		} elsif($attr eq "hash") {
 			croak "hash specified redundantly"
 				if exists($self->{hash}) ||

--- a/lib/Authen/Passphrase/Crypt16.pm
+++ b/lib/Authen/Passphrase/Crypt16.pm
@@ -70,7 +70,7 @@ use Authen::Passphrase 0.003;
 use Authen::Passphrase::DESCrypt;
 use Carp qw(croak);
 use Crypt::UnixCrypt_XS 0.08 qw(base64_to_block base64_to_int12);
-use Data::Entropy::Algorithms 0.000 qw(rand_int);
+use Crypt::PRNG 0.000 qw(irand);
 
 our $VERSION = "0.008";
 
@@ -147,7 +147,7 @@ sub new {
 				if defined $salt;
 			croak "\"$value\" is not a valid salt size"
 				unless $value == 12;
-			$salt = rand_int(1 << $value);
+			$salt = irand() % (1 << $value);
 		} elsif($attr eq "hash") {
 			croak "hash specified redundantly"
 				if defined($hash) || defined($passphrase);

--- a/lib/Authen/Passphrase/DESCrypt.pm
+++ b/lib/Authen/Passphrase/DESCrypt.pm
@@ -127,7 +127,7 @@ use Crypt::UnixCrypt_XS 0.08 qw(
 	base64_to_int24 int24_to_base64
 	base64_to_int12 int12_to_base64
 );
-use Data::Entropy::Algorithms 0.000 qw(rand_int);
+use Crypt::PRNG 0.000 qw(irand);
 
 our $VERSION = "0.008";
 
@@ -260,7 +260,7 @@ sub new {
 				if exists $self->{salt};
 			croak "\"$value\" is not a valid salt size"
 				unless $value == 12 || $value == 24;
-			$self->{salt} = rand_int(1 << $value);
+			$self->{salt} = irand() % (1 << $value);
 		} elsif($attr eq "hash") {
 			croak "hash specified redundantly"
 				if exists($self->{hash}) ||

--- a/lib/Authen/Passphrase/MD5Crypt.pm
+++ b/lib/Authen/Passphrase/MD5Crypt.pm
@@ -85,7 +85,7 @@ use strict;
 use Authen::Passphrase 0.003;
 use Carp qw(croak);
 use Crypt::PasswdMD5 1.0 qw(unix_md5_crypt);
-use Data::Entropy::Algorithms 0.000 qw(rand_int);
+use Crypt::PRNG 0.000 qw(irand);
 
 our $VERSION = "0.008";
 
@@ -147,7 +147,7 @@ sub new {
 				if exists $self->{salt};
 			$self->{salt} = "";
 			for(my $i = 8; $i--; ) {
-				$self->{salt} .= chr(rand_int(64));
+				$self->{salt} .= chr(irand() % (64));
 			}
 			$self->{salt} =~ tr#\x00-\x3f#./0-9A-Za-z#;
 		} elsif($attr eq "hash_base64") {

--- a/lib/Authen/Passphrase/NetscapeMail.pm
+++ b/lib/Authen/Passphrase/NetscapeMail.pm
@@ -52,7 +52,7 @@ use strict;
 
 use Authen::Passphrase 0.003;
 use Carp qw(croak);
-use Data::Entropy::Algorithms 0.000 qw(rand_bits);
+use Crypt::PRNG 0.000 qw(random_bytes);
 use Digest::MD5 1.99_53 ();
 
 our $VERSION = "0.008";
@@ -116,7 +116,7 @@ sub new {
 		} elsif($attr eq "salt_random") {
 			croak "salt specified redundantly"
 				if exists $self->{salt};
-			$self->{salt} = unpack("H*", rand_bits(128));
+			$self->{salt} = unpack("H*", random_bytes(16));
 		} elsif($attr eq "hash") {
 			croak "hash specified redundantly"
 				if exists($self->{hash}) ||

--- a/lib/Authen/Passphrase/PHPass.pm
+++ b/lib/Authen/Passphrase/PHPass.pm
@@ -66,7 +66,7 @@ use strict;
 
 use Authen::Passphrase 0.003;
 use Carp qw(croak);
-use Data::Entropy::Algorithms 0.000 qw(rand_bits);
+use Crypt::PRNG 0.000 qw(random_bytes);
 use Digest::MD5 1.99_53 ();
 
 our $VERSION = "0.008";
@@ -201,7 +201,7 @@ sub new {
 		} elsif($attr eq "salt_random") {
 			croak "salt specified redundantly"
 				if exists $self->{salt};
-			$self->{salt} = _en_base64(rand_bits(48));
+			$self->{salt} = _en_base64(random_bytes(6));
 		} elsif($attr eq "hash") {
 			croak "hash specified redundantly"
 				if exists($self->{hash}) ||

--- a/lib/Authen/Passphrase/SaltedDigest.pm
+++ b/lib/Authen/Passphrase/SaltedDigest.pm
@@ -75,7 +75,7 @@ use strict;
 
 use Authen::Passphrase 0.003;
 use Carp qw(croak);
-use Data::Entropy::Algorithms 0.000 qw(rand_bits);
+use Crypt::PRNG 0.000 qw(random_bytes);
 use Digest 1.00;
 use MIME::Base64 2.21 qw(encode_base64 decode_base64);
 use Module::Runtime 0.011 qw(is_valid_module_name use_module);
@@ -186,7 +186,7 @@ sub new {
 				if exists $self->{salt};
 			croak "\"$value\" is not a valid salt length"
 				unless $value == int($value) && $value >= 0;
-			$self->{salt} = rand_bits($value * 8);
+			$self->{salt} = random_bytes($value);
 		} elsif($attr eq "hash") {
 			croak "hash specified redundantly"
 				if exists($self->{hash}) ||

--- a/lib/Authen/Passphrase/VMSPurdy.pm
+++ b/lib/Authen/Passphrase/VMSPurdy.pm
@@ -81,7 +81,7 @@ use strict;
 use Authen::DecHpwd 2.003 qw(lgi_hpwd UAI_C_PURDY UAI_C_PURDY_V UAI_C_PURDY_S);
 use Authen::Passphrase 0.003;
 use Carp qw(croak);
-use Data::Entropy::Algorithms 0.000 qw(rand_int);
+use Crypt::PRNG 0.000 qw(irand);
 
 our $VERSION = "0.008";
 
@@ -181,7 +181,7 @@ sub new {
 		} elsif($attr eq "salt_random") {
 			croak "salt specified redundantly"
 				if exists $self->{salt};
-			$self->{salt} = rand_int(65536);
+			$self->{salt} = irand() % (65536);
 		} elsif($attr eq "hash") {
 			croak "hash specified redundantly"
 				if exists($self->{hash}) ||


### PR DESCRIPTION
This patch is from the attachment on RT#167253 by Mathieu Arnold

https://rt.cpan.org/Public/Bug/Display.html?id=167253