### PR TITLE
Crypt format compat: $2b$ and $2y$

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+{{$NEXT}}
+  
+  * support $2y$ crypt format for ::BlowfishCrypt, RT#133259 (Wes Malone)
+
 version 0.008; 2012-02-04
 
   * bugfix: avoid passing magic variables $1 et al into functions where

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 {{$NEXT}}
   
-  * support $2y$ crypt format for ::BlowfishCrypt, RT#133259 (Wes Malone)
+  * support $2y$ & $2b$ crypt formats for ::BlowfishCrypt, RT#133259 (Wes Malone)
 
 version 0.008; 2012-02-04
 

--- a/lib/Authen/Passphrase.pm
+++ b/lib/Authen/Passphrase.pm
@@ -173,9 +173,12 @@ L<Authen::Passphrase::MD5Crypt>.
 
 =item B<$2y$>
 
+=item B<$2b$>
+
 Two versions of a passphrase scheme based on Blowfish,
-designed by Niels Provos and David Mazieres for OpenBSD.  "$2y$" is
-treated as an alias of "$2a$".  See L<Authen::Passphrase::BlowfishCrypt>.
+designed by Niels Provos and David Mazieres for OpenBSD.  "$2y$" and
+"$2b$" are treated as aliases of "$2a$" (no functional difference within
+this distribution).  See L<Authen::Passphrase::BlowfishCrypt>.
 
 =item B<$3$>
 
@@ -275,6 +278,7 @@ my %crypt_scheme_handler = (
 	"1"    => [ "Authen::Passphrase::MD5Crypt", 0.003 ],
 	"2"    => [ "Authen::Passphrase::BlowfishCrypt", 0.007 ],
 	"2a"   => [ "Authen::Passphrase::BlowfishCrypt", 0.007 ],
+	"2b"   => [ "Authen::Passphrase::BlowfishCrypt", 0.007 ],
 	"2y"   => [ "Authen::Passphrase::BlowfishCrypt", 0.007 ],
 	"3"    => [ "Authen::Passphrase::NTHash", 0.003 ],
 	"IPB2" => sub($) { croak '$IPB2$ is unimplemented' },

--- a/lib/Authen/Passphrase.pm
+++ b/lib/Authen/Passphrase.pm
@@ -171,9 +171,11 @@ L<Authen::Passphrase::MD5Crypt>.
 
 =item B<$2a$>
 
+=item B<$2y$>
+
 Two versions of a passphrase scheme based on Blowfish,
-designed by Niels Provos and David Mazieres for OpenBSD.  See
-L<Authen::Passphrase::BlowfishCrypt>.
+designed by Niels Provos and David Mazieres for OpenBSD.  "$2y$" is
+treated as an alias of "$2a$".  See L<Authen::Passphrase::BlowfishCrypt>.
 
 =item B<$3$>
 
@@ -273,6 +275,7 @@ my %crypt_scheme_handler = (
 	"1"    => [ "Authen::Passphrase::MD5Crypt", 0.003 ],
 	"2"    => [ "Authen::Passphrase::BlowfishCrypt", 0.007 ],
 	"2a"   => [ "Authen::Passphrase::BlowfishCrypt", 0.007 ],
+	"2y"   => [ "Authen::Passphrase::BlowfishCrypt", 0.007 ],
 	"3"    => [ "Authen::Passphrase::NTHash", 0.003 ],
 	"IPB2" => sub($) { croak '$IPB2$ is unimplemented' },
 	"K4"   => sub($) { croak '$K4$ is unimplemented' },

--- a/lib/Authen/Passphrase/BlowfishCrypt.pm
+++ b/lib/Authen/Passphrase/BlowfishCrypt.pm
@@ -230,18 +230,19 @@ sub new {
 
 Generates a new passphrase recogniser object using the Blowfish-based
 crypt() algorithm, from a crypt string.  The crypt string must start with
-"B<$2$>" for the version that does not append NUL to the key, or either
-"B<$2a$>" or "B<$2y$>" for the version that does.  The next two characters
-must be decimal digits giving the cost parameter.  This must be followed by
-"B<$>", 22 base 64 digits giving the salt, and finally 31 base 64 digits
-giving the hash.  "$2y$" is treated as an alias of "$2a$".
+"B<$2$>" for the version that does not append NUL to the key, or any of
+"B<$2a$>", "B<$2y$>", or "B<$2b$>" for the version that does.  The next
+two characters must be decimal digits giving the cost parameter.  This must
+be followed by "B<$>", 22 base 64 digits giving the salt, and finally 31
+base 64 digits giving the hash.  "$2y$" and "$2b$" are treated as aliases
+of "$2a$".
 
 =cut
 
 sub from_crypt {
 	my($class, $passwd) = @_;
-	if($passwd =~ /\A(\$2[ay]?\$)/) {
-		$passwd =~ m#\A\$2([ay]?)\$([0-9]{2})\$
+	if($passwd =~ /\A(\$2[aby]?\$)/) {
+		$passwd =~ m#\A\$2([aby]?)\$([0-9]{2})\$
 				([./A-Za-z0-9]{22})([./A-Za-z0-9]{31})\z#x
 			or croak "malformed $1 data";
 		my($kn, $cost, $salt, $hash) = ($1, $2, $3, $4);

--- a/lib/Authen/Passphrase/BlowfishCrypt.pm
+++ b/lib/Authen/Passphrase/BlowfishCrypt.pm
@@ -230,17 +230,18 @@ sub new {
 
 Generates a new passphrase recogniser object using the Blowfish-based
 crypt() algorithm, from a crypt string.  The crypt string must start with
-"B<$2$>" for the version that does not append NUL to the key, or "B<$2a$>"
-for the version that does.  The next two characters must be decimal digits
-giving the cost parameter.  This must be followed by "B<$>", 22 base 64
-digits giving the salt, and finally 31 base 64 digits giving the hash.
+"B<$2$>" for the version that does not append NUL to the key, or either
+"B<$2a$>" or "B<$2y$>" for the version that does.  The next two characters
+must be decimal digits giving the cost parameter.  This must be followed by
+"B<$>", 22 base 64 digits giving the salt, and finally 31 base 64 digits
+giving the hash.  "$2y$" is treated as an alias of "$2a$".
 
 =cut
 
 sub from_crypt {
 	my($class, $passwd) = @_;
-	if($passwd =~ /\A(\$2a?\$)/) {
-		$passwd =~ m#\A\$2(a?)\$([0-9]{2})\$
+	if($passwd =~ /\A(\$2[ay]?\$)/) {
+		$passwd =~ m#\A\$2([ay]?)\$([0-9]{2})\$
 				([./A-Za-z0-9]{22})([./A-Za-z0-9]{31})\z#x
 			or croak "malformed $1 data";
 		my($kn, $cost, $salt, $hash) = ($1, $2, $3, $4);

--- a/t/blowfishcrypt.t
+++ b/t/blowfishcrypt.t
@@ -1,7 +1,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 110;
+use Test::More tests => 117;
 
 BEGIN { use_ok "Authen::Passphrase::BlowfishCrypt"; }
 
@@ -84,12 +84,32 @@ $ppr = Authen::Passphrase::BlowfishCrypt
 		     'JjrUXrZskQrnTq0SOwFkM0sRsvuzqC');
 ok $ppr->key_nul;
 
+# $2b$ support (same as $2a$)
+$ppr = Authen::Passphrase::BlowfishCrypt
+	->from_crypt('$2b$08$s5VYb9QzBzTUE3h66kH6hOQ'.
+		     'JjrUXrZskQrnTq0SOwFkM0sRsvuzqC');
+ok $ppr;
+ok $ppr->key_nul;
+is $ppr->cost, 8;
+is $ppr->salt_base64, 's5VYb9QzBzTUE3h66kH6hO';
+is $ppr->hash_base64, 'QJjrUXrZskQrnTq0SOwFkM0sRsvuzqC';
+
+$ppr = Authen::Passphrase::BlowfishCrypt
+	->from_rfc2307('{CRYPT}$2b$08$s5VYb9QzBzTUE3h66kH6hOQ'.
+		     'JjrUXrZskQrnTq0SOwFkM0sRsvuzqC');
+ok $ppr->key_nul;
+
 # Base class dispatch to ensure Authen::Passphrase->from_crypt works
 use Authen::Passphrase;
-my $base = Authen::Passphrase
+my $base_y = Authen::Passphrase
 	->from_crypt('$2y$08$s5VYb9QzBzTUE3h66kH6hOQ'.
 		     'JjrUXrZskQrnTq0SOwFkM0sRsvuzqC');
-ok $base->isa('Authen::Passphrase::BlowfishCrypt'), 'Base class from_crypt returns BlowfishCrypt for $2y$';
+ok $base_y->isa('Authen::Passphrase::BlowfishCrypt'), 'Base class from_crypt returns BlowfishCrypt for $2y$';
+
+my $base_b = Authen::Passphrase
+	->from_crypt('$2b$08$s5VYb9QzBzTUE3h66kH6hOQ'.
+		     'JjrUXrZskQrnTq0SOwFkM0sRsvuzqC');
+ok $base_b->isa('Authen::Passphrase::BlowfishCrypt'), 'Base class from_crypt returns BlowfishCrypt for $2b$';
 
 my %pprs;
 while(<DATA>) {

--- a/t/blowfishcrypt.t
+++ b/t/blowfishcrypt.t
@@ -1,7 +1,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 103;
+use Test::More tests => 110;
 
 BEGIN { use_ok "Authen::Passphrase::BlowfishCrypt"; }
 
@@ -68,6 +68,28 @@ ok $ppr->key_nul;
 is $ppr->cost, 8;
 is $ppr->salt_base64, "s5VYb9QzBzTUE3h66kH6hO";
 is $ppr->hash_base64, "QJjrUXrZskQrnTq0SOwFkM0sRsvuzqC";
+
+# $2y$ support (same as $2a$)
+$ppr = Authen::Passphrase::BlowfishCrypt
+	->from_crypt('$2y$08$s5VYb9QzBzTUE3h66kH6hOQ'.
+		     'JjrUXrZskQrnTq0SOwFkM0sRsvuzqC');
+ok $ppr;
+ok $ppr->key_nul;
+is $ppr->cost, 8;
+is $ppr->salt_base64, 's5VYb9QzBzTUE3h66kH6hO';
+is $ppr->hash_base64, 'QJjrUXrZskQrnTq0SOwFkM0sRsvuzqC';
+
+$ppr = Authen::Passphrase::BlowfishCrypt
+	->from_rfc2307('{CRYPT}$2y$08$s5VYb9QzBzTUE3h66kH6hOQ'.
+		     'JjrUXrZskQrnTq0SOwFkM0sRsvuzqC');
+ok $ppr->key_nul;
+
+# Base class dispatch to ensure Authen::Passphrase->from_crypt works
+use Authen::Passphrase;
+my $base = Authen::Passphrase
+	->from_crypt('$2y$08$s5VYb9QzBzTUE3h66kH6hOQ'.
+		     'JjrUXrZskQrnTq0SOwFkM0sRsvuzqC');
+ok $base->isa('Authen::Passphrase::BlowfishCrypt'), 'Base class from_crypt returns BlowfishCrypt for $2y$';
 
 my %pprs;
 while(<DATA>) {


### PR DESCRIPTION
Accept bcrypt hashes with additional prefix markers. These prefixes denote hashes produced by other bcrypts that fixed implementation-specific bugs.

* `$2y$` - PHP's Crypt_Blowfish and others, including Apache htpasswd
* `$2b$` - OpenBSD

These formats are NUL terminated like `$2a$` and can be handled the same.